### PR TITLE
Added a delay to fix glitchy initial animation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,7 @@ particlesJS.load("particles-js", "particles.json", function () {
 /*       --- Mid Heavy Timeline Animation ---       */
 var basicTimeline = anime.timeline()
 basicTimeline.reverse()
-var TIME_MULTIPLIER = 1.45
+var TIME_MULTIPLIER = 1.3
 
 function H() {
   // Make the line visible
@@ -61,4 +61,5 @@ basicTimeline
 
   .add(Front(`#frontPath1`))
   .add(Back(`#backPath1`))
+  .add({targets: 'p', color: 'rgba(214, 214, 214, 0)', duration: TIME_MULTIPLIER * 500})
 // **Start Here**


### PR DESCRIPTION
Added a delay to fix glitchy initial animation, also made the MidHeavy.Tech fade in during the delay because it looked naked on its own.
sped up the time factor a little cause it doesn't fall apart as much at faster values anymore.

https://user-images.githubusercontent.com/83617863/126950084-9b236977-32e8-4d0f-b81c-8aedc145e2a6.mp4

