### PR TITLE
fixed scolling. hopefully for real this time

### DIFF
--- a/src/components/particles.json
+++ b/src/components/particles.json
@@ -62,7 +62,7 @@
     }
   },
   "interactivity": {
-    "detect_on": "canvas",
+    "detect_on": "window",
     "events": {
       "onhover": {
         "enable": false,


### PR DESCRIPTION
this fixed the scrolling ( as far as i can tell )
a simple change to the particles.json file. under "interactivity" the "detect on" is now set to "window" instead of "canvas"
i really don't know why, but when it was set to canvas it seemed not to accept zindex instructions and was always directly on top, (other than elements like the tiles) and it was not a scrollable element, so scrolling while you were on anything other than elements like the tiles did not work.